### PR TITLE
Change initialize get set for projection matrix

### DIFF
--- a/src/MonoGame.Framework.Graphics.Scene3D/ModelDrawingContext.cs
+++ b/src/MonoGame.Framework.Graphics.Scene3D/ModelDrawingContext.cs
@@ -14,10 +14,9 @@ namespace Microsoft.Xna.Framework.Graphics
         public ModelDrawingContext(GraphicsDevice graphics)
         {
             _Device = graphics;
-
             _Device.DepthStencilState = DepthStencilState.Default;            
-
             _View = Matrix.Invert(Matrix.Identity);
+            _Projection = SceneUtils.CreatePerspectiveFieldOfView(_FieldOfView, _Device.Viewport.AspectRatio, _NearPlane);
             _DistanceComparer = ModelInstance.GetDistanceComparer(-_View.Translation);
         }
         
@@ -32,7 +31,7 @@ namespace Microsoft.Xna.Framework.Graphics
         private float _FieldOfView = MathHelper.PiOver4;
         private float _NearPlane = 1f;
         
-        private Matrix _View;
+        private Matrix _View, _Projection;
         private IComparer<ModelInstance> _DistanceComparer;
 
         private static readonly HashSet<Effect> _SceneEffects = new HashSet<Effect>();
@@ -73,13 +72,18 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public Matrix GetProjectionMatrix()
         {
-            return SceneUtils.CreatePerspectiveFieldOfView(_FieldOfView, _Device.Viewport.AspectRatio, _NearPlane);
+            return _Projection;
+        }
+
+        public void SetProjectionMatrix(Matrix projectionMatrix)
+        {
+            _Projection = projectionMatrix;
         }
 
         public void SetCamera(Matrix cameraMatrix)
         {
             _View = Matrix.Invert(cameraMatrix);
-
+            _Projection = SceneUtils.CreatePerspectiveFieldOfView(_FieldOfView, _Device.Viewport.AspectRatio, _NearPlane);
             _DistanceComparer = ModelInstance.GetDistanceComparer(-_View.Translation);
         }
 


### PR DESCRIPTION
Changed the _Projection to be cached default is initialized setter is added.
Didn't bother to add a create projection matrix from the scene utilitys function.